### PR TITLE
Re-add event type

### DIFF
--- a/lib/filedrop.ts
+++ b/lib/filedrop.ts
@@ -192,3 +192,9 @@ export class FileDropElement extends HTMLElement {
 }
 
 customElements.define('file-drop', FileDropElement);
+
+declare global {
+  interface HTMLElementEventMap {
+    'filedrop': FileDropEvent;
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,7 @@
 {
   "compileOnSave": false,
   "files": [
-    "lib/filedrop.ts",
-    "./node_modules/preact/dist/preact"
+    "lib/filedrop.ts"
   ],
   "compilerOptions": {
     "strict": true,


### PR DESCRIPTION
`HTMLElementEventMap` is a built-in TypeScript type, not a Preact type. Leaving this in allows for event listeners to automatically recognize that the `"filedrop"` event has the `.files` property.